### PR TITLE
Fix nginx configuration for updated Realtime SIP connection

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,56 @@
+#
+# This source file is part of the ENGAGE-HF-AI-Voice open source project
+#
+# SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+# 
+
+
+version: '3.8'
+
+services:
+  app:
+    image: ghcr.io/stanfordbdhg/engage-hf-ai-voice:main
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY}
+      - INTERNAL_TESTING_MODE=${INTERNAL_TESTING_MODE}
+    volumes:
+      - app-data:/app/Data
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  nginx:
+    image: nginx:alpine
+    container_name: nginx-proxy
+    restart: unless-stopped
+    ports:
+      - "8080:80"
+      - "443:443"
+    volumes:
+      - ./nginx.local.conf:/etc/nginx/nginx.conf:ro
+    networks:
+      - app-network
+    depends_on:
+      - app
+
+  watchtower:
+    image: containrrr/watchtower
+    restart: always
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --cleanup=true
+
+networks:
+  app-network:
+    driver: bridge
+
+volumes:
+  app-data:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -33,7 +33,6 @@ services:
     restart: unless-stopped
     ports:
       - "8080:80"
-      - "443:443"
     volumes:
       - ./nginx.local.conf:/etc/nginx/nginx.conf:ro
     networks:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -40,13 +40,6 @@ services:
     depends_on:
       - app
 
-  watchtower:
-    image: containrrr/watchtower
-    restart: always
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    command: --cleanup=true
-
 networks:
   app-network:
     driver: bridge

--- a/nginx.conf
+++ b/nginx.conf
@@ -55,11 +55,6 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            
-            # WebSocket support
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
         }
     }
 }

--- a/nginx.local.conf
+++ b/nginx.local.conf
@@ -1,0 +1,31 @@
+#
+# This source file is part of the ENGAGE-HF-AI-Voice open source project
+#
+# SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+# 
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream app {
+        server app:8080;
+    }
+
+    # HTTPS server
+    server {
+        http2 on;
+
+        # Proxy to app
+        location / {
+            proxy_pass http://app;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/nginx.local.conf
+++ b/nginx.local.conf
@@ -15,7 +15,6 @@ http {
         server app:8080;
     }
 
-    # HTTPS server
     server {
         http2 on;
 


### PR DESCRIPTION
# Fix nginx configuration for updated Realtime SIP connection

## :recycle: Current situation & Problem
We have changed to the new Realtime API with SIP system when connecting a phone number to the OpenAI Realtime API. Rather than forwarding a voice data stream from Twilio on our server and forwarding it to OpenAI and then forwarding their traffic back to Twilio, we are now able to connect Twilio directly to OpenAI using Elastic SIP Trunking.

My local deployment didn't actually cause any issues with that - but apparently the nginx configuration contained a few settings that would keep the initial webhook open for longer than expected. 

This PR not only fixes the nginx configuration to no longer include those websocket-related lines, but also adds a local docker compose setup (including a specialized nginx config that doesn't include the HTTPS and domain settings).


## :gear: Release Notes
- Adapts nginx.conf to no longer have websocket-related contents
- Adds docker-compose.local.yml and nginx.local.conf for local debugging of nginx-related issues.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
