### PR TITLE
Enable combined answers for BP

### DIFF
--- a/Sources/App/Services/CallHandler.swift
+++ b/Sources/App/Services/CallHandler.swift
@@ -154,7 +154,7 @@ actor CallHandler {
             + Constants.noUnansweredQuestionsLeft
             + Constants.feedback(content: feedback ?? "Feedback failed to be retrieved.")
         } else {
-            let initialQuestion = await serviceState.current.getNextQuestion()
+            let initialQuestion = await serviceState.current.getNextQuestion(includeAllQuestions: true)
             let initialSystemMessage = await Constants.getSystemMessageForService(
                 serviceState.current,
                 initialQuestion: initialQuestion

--- a/Sources/App/Services/CallSession.swift
+++ b/Sources/App/Services/CallSession.swift
@@ -187,7 +187,7 @@ actor CallSession {
         service: any QuestionnaireService,
         response: OpenAIResponse
     ) async throws {
-        if let nextQuestion = await service.getNextQuestion() {
+        if let nextQuestion = await service.getNextQuestion(includeAllQuestions: false) {
             try await handleNextQuestionAvailable(nextQuestion: nextQuestion, response: response)
         } else {
             try await handleQuestionnaireComplete(service: service, response: response)
@@ -216,7 +216,7 @@ actor CallSession {
         await service.saveQuestionnaireResponseToFile()
         
         if let nextService = await serviceState.next(),
-           let initialQuestion = await nextService.getNextQuestion(),
+           let initialQuestion = await nextService.getNextQuestion(includeAllQuestions: true),
            let systemMessage = Constants.getSystemMessageForService(nextService, initialQuestion: initialQuestion) {
             try await handleNextServiceAvailable(
                 nextService: nextService,

--- a/Sources/App/Services/Helper/BaseQuestionnaireService.swift
+++ b/Sources/App/Services/Helper/BaseQuestionnaireService.swift
@@ -28,6 +28,7 @@ class BaseQuestionnaireService: QuestionnaireService, Sendable {
         directoryPath: String,
         phoneNumber: String,
         logger: Logger,
+        sharesAllQuestionsIfNeeded: Bool,
         featureFlags: FeatureFlags,
         encryptionKey: String? = nil
     ) {
@@ -41,14 +42,15 @@ class BaseQuestionnaireService: QuestionnaireService, Sendable {
         )
         self.manager = QuestionnaireManager(
             questionnaire: storage.loadQuestionnaire(),
+            sharesAllQuestionsIfNeeded: sharesAllQuestionsIfNeeded,
             initialResponse: storage.loadQuestionnaireResponse(phoneNumber: phoneNumber, logger: logger)
         )
     }
     
     /// Get the next question from the questionnaire
     /// - Returns: The next question as a JSON string if available, nil if no more questions
-    func getNextQuestion() async -> String? {
-        manager.getNextQuestionString()
+    func getNextQuestion(includeAllQuestions: Bool) async -> String? {
+        manager.getNextQuestionString(includeAllQuestions: includeAllQuestions)
     }
     
     /// Save the questionnaire response to the file by delegating to the storage service

--- a/Sources/App/Services/Helper/QuestionWithProgress.swift
+++ b/Sources/App/Services/Helper/QuestionWithProgress.swift
@@ -12,9 +12,11 @@ import ModelsR4
 /// A struct to wrap the question and progress
 struct QuestionWithProgress: Codable {
     enum CodingKeys: String, CodingKey {
-        case question, progress
+        case question, progress, allQuestions
     }
 
     let question: QuestionnaireItem
     let progress: String
+    // swiftlint:disable:next discouraged_optional_collection
+    let allQuestions: [QuestionnaireItem]?
 }

--- a/Sources/App/Services/Helper/QuestionnaireManager.swift
+++ b/Sources/App/Services/Helper/QuestionnaireManager.swift
@@ -94,7 +94,7 @@ class QuestionnaireManager: Sendable {
         let answeredCount = answeredLinkIds.count
         let progress = "\(answeredCount + 1) of \(totalQuestions)"
         
-        let unansweredQuestions = sharesAllQuestionsIfNeeded
+        let unansweredQuestions = (sharesAllQuestionsIfNeeded && includeAllQuestions)
             ? questions.filter { question in
                 guard let linkId = question.linkId.value?.string else {
                     return false

--- a/Sources/App/Services/Helper/QuestionnaireService.swift
+++ b/Sources/App/Services/Helper/QuestionnaireService.swift
@@ -17,7 +17,7 @@ protocol QuestionnaireService: Sendable {
     var phoneNumber: String { get }
     var logger: Logger { get }
     
-    func getNextQuestion() async -> String?
+    func getNextQuestion(includeAllQuestions: Bool) async -> String?
     func saveQuestionnaireResponseToFile() async
     func saveQuestionnaireAnswer<T>(linkId: String, answer: T) -> Bool
     func countAnsweredQuestions() -> Int

--- a/Sources/App/Services/KCCQ12Service.swift
+++ b/Sources/App/Services/KCCQ12Service.swift
@@ -20,6 +20,7 @@ class KCCQ12Service: BaseQuestionnaireService, Sendable {
             directoryPath: Constants.kccq12DirectoryPath,
             phoneNumber: phoneNumber,
             logger: logger,
+            sharesAllQuestionsIfNeeded: false,
             featureFlags: featureFlags,
             encryptionKey: encryptionKey
         )

--- a/Sources/App/Services/Q17Service.swift
+++ b/Sources/App/Services/Q17Service.swift
@@ -20,6 +20,7 @@ class Q17Service: BaseQuestionnaireService, Sendable {
             directoryPath: Constants.q17DirectoryPath,
             phoneNumber: phoneNumber,
             logger: logger,
+            sharesAllQuestionsIfNeeded: false,
             featureFlags: featureFlags,
             encryptionKey: encryptionKey
         )

--- a/Sources/App/Services/VitalSignsService.swift
+++ b/Sources/App/Services/VitalSignsService.swift
@@ -20,6 +20,7 @@ class VitalSignsService: BaseQuestionnaireService, Sendable {
             directoryPath: Constants.vitalSignsDirectoryPath,
             phoneNumber: phoneNumber,
             logger: logger,
+            sharesAllQuestionsIfNeeded: true,
             featureFlags: featureFlags,
             encryptionKey: encryptionKey
         )

--- a/Sources/App/constants.swift
+++ b/Sources/App/constants.swift
@@ -31,6 +31,9 @@ enum Constants {
       - If the number is not 0, inform the user about their progress and that you will continue with the remaining questions.
       - If the number is 0, inform the user that you will start with the first question.
     - Always pronounce units in their long form, e.g., say "Millimeters of Mercury" for "mmHg".
+    - When you receive the initial question, it will include an "allQuestions" field listing all questions in this section.
+      - Use this information to understand which linkIds are available for saving responses.
+      - You can use this to handle related questions together when appropriate.
 
     For each question:
     - Ask the question text clearly to the patient.
@@ -41,6 +44,17 @@ enum Constants {
     - If the patient indicates that they do not have an answer to the current question, use `null` as answer value.
     - Always save the answer using the question's linkId and the save_response function.
     - Move to the next question after saving. Ensure the conversation remains fluent and engaging.
+
+    BLOOD PRESSURE HANDLING:
+    - When asking blood pressure questions, you can collect the values in two ways:
+      1. Sequentially (preferred): Ask for systolic first, then diastolic in separate questions.
+      2. Together (if provided): If the patient provides both values at once (e.g., "120 over 70" or "120/70"), you can save them together.
+    - When the patient provides both blood pressure values together:
+      - Parse the systolic (first number) and diastolic (second number) from their response.
+      - Confirm both values with the patient.
+      - Save the systolic value using linkId "systolic" by calling save_response.
+      - Immediately after, save the diastolic value using linkId "diastolic" by calling save_response.
+    - Sequential collection is still preferred when starting fresh, but accept combined responses to save time.
 
     IMPORTANT:
     - Call save_response after each response is confirmed, but only if the response is in the expected range.


### PR DESCRIPTION
# Enable combined answers for BP

## :recycle: Current situation & Problem
Based on #32, it introduces the capability to sometimes provide the entire set of questions alongside the next one. For vital signs, we for example want the AI to know about all the questions. In the case of KCCQ-12, it would actually be too many questions at once and force-closing the connection...


## :gear: Release Notes
- Provides all questions in the initial section session config update, if the questionnaire service is configured accordingly.
- Only VitalSignService actually provides that functionality.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
