### PR TITLE
Save questionnaire responses on each save of an answer

### DIFF
--- a/Sources/App/Services/CallSession.swift
+++ b/Sources/App/Services/CallSession.swift
@@ -212,9 +212,7 @@ actor CallSession {
     private func handleQuestionnaireComplete(
         service: any QuestionnaireService,
         response: OpenAIResponse
-    ) async throws {
-        await service.saveQuestionnaireResponseToFile()
-        
+    ) async throws {       
         if let nextService = await serviceState.next(),
            let initialQuestion = await nextService.getNextQuestion(),
            let systemMessage = Constants.getSystemMessageForService(nextService, initialQuestion: initialQuestion) {

--- a/Sources/App/Services/Helper/BaseQuestionnaireService.swift
+++ b/Sources/App/Services/Helper/BaseQuestionnaireService.swift
@@ -51,23 +51,15 @@ class BaseQuestionnaireService: QuestionnaireService, Sendable {
         manager.getNextQuestionString()
     }
     
-    /// Save the questionnaire response to the file by delegating to the storage service
-    func saveQuestionnaireResponseToFile() async {
-        let response = manager.getCurrentResponse()
-        await storage.saveQuestionnaireResponse(phoneNumber: phoneNumber, response: response, logger: logger)
-    }
-    
     /// Save the answer to a question to the questionnaire response managed by the manager
     /// - Parameters:
     ///   - linkId: The question's identifier
     ///   - answer: The answer to the question
     /// - Returns: True if the answer was saved successfully, false otherwise
-    func saveQuestionnaireAnswer<T>(linkId: String, answer: T) -> Bool {
+    func saveQuestionnaireAnswer<T>(linkId: String, answer: T) async -> Bool {
         do {
             try manager.answerQuestion(linkId: linkId, answer: answer)
-            Task {
-                await saveQuestionnaireResponseToFile()
-            }
+            await saveQuestionnaireResponseToFile()
             return true
         } catch {
             logger.error("Error saving Questionnaire Answer: \(error)")
@@ -85,5 +77,13 @@ class BaseQuestionnaireService: QuestionnaireService, Sendable {
     /// - Returns: True if there are any unanswered questions left, false otherwise
     func unansweredQuestionsLeft() -> Bool {
         !manager.isFinished
+    }
+    
+    // Helpers
+    
+    /// Save the questionnaire response to the file by delegating to the storage service
+    private func saveQuestionnaireResponseToFile() async {
+        let response = manager.getCurrentResponse()
+        await storage.saveQuestionnaireResponse(phoneNumber: phoneNumber, response: response, logger: logger)
     }
 }

--- a/Sources/App/Services/Helper/BaseQuestionnaireService.swift
+++ b/Sources/App/Services/Helper/BaseQuestionnaireService.swift
@@ -65,6 +65,9 @@ class BaseQuestionnaireService: QuestionnaireService, Sendable {
     func saveQuestionnaireAnswer<T>(linkId: String, answer: T) -> Bool {
         do {
             try manager.answerQuestion(linkId: linkId, answer: answer)
+            Task {
+                await saveQuestionnaireResponseToFile()
+            }
             return true
         } catch {
             logger.error("Error saving Questionnaire Answer: \(error)")

--- a/Sources/App/Services/Helper/QuestionnaireService.swift
+++ b/Sources/App/Services/Helper/QuestionnaireService.swift
@@ -18,8 +18,7 @@ protocol QuestionnaireService: Sendable {
     var logger: Logger { get }
     
     func getNextQuestion() async -> String?
-    func saveQuestionnaireResponseToFile() async
-    func saveQuestionnaireAnswer<T>(linkId: String, answer: T) -> Bool
+    func saveQuestionnaireAnswer<T>(linkId: String, answer: T) async -> Bool
     func countAnsweredQuestions() -> Int
     func unansweredQuestionsLeft() -> Bool
 }


### PR DESCRIPTION
# Save questionnaire responses on each save of an answer

## :recycle: Current situation & Problem
When a patient just hangs up or the call gets disconnected for a variety of possible reasons, we want to make sure that each response given is still stored. 


## :gear: Release Notes
- Questionnaire responses are saved on each answer given rather than only when a questionnaire is fully finished.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
