### PR TITLE
Hashed file names for call recordings

### DIFF
--- a/Sources/App/Services/CallRecordingService.swift
+++ b/Sources/App/Services/CallRecordingService.swift
@@ -53,8 +53,10 @@ actor CallRecordingService {
                         
             do {
                 let call = try await api.fetchCall(sid: recording.callSid)
-                let dateCreatedString = parseTwilioDate(from: recording.dateCreated).map(filePathUsableDateString)
-                let fileNamePrefix = dateCreatedString.map { "\(call.from)_\($0)" } ?? call.from
+                guard let twilioDate = parseTwilioDate(from: recording.dateCreated) else {
+                    throw Abort(.badRequest)
+                }
+                let fileNamePrefix = fileName(phoneNumber: call.from, date: twilioDate, internalTestingMode: false)
                 let wavURL = directory.appending(component: fileNamePrefix + fileNameSuffixWAV)
                 let jsonURL = directory.appending(component: fileNamePrefix + fileNameSuffixJSON)
                 let data = try await api.fetchMediaFile(sid: recording.sid)

--- a/Sources/App/Services/CallRecordingService.swift
+++ b/Sources/App/Services/CallRecordingService.swift
@@ -54,7 +54,7 @@ actor CallRecordingService {
             do {
                 let call = try await api.fetchCall(sid: recording.callSid)
                 guard let twilioDate = parseTwilioDate(from: recording.dateCreated) else {
-                    throw Abort(.badRequest)
+                    throw Abort(.unprocessableEntity, reason: "Invalid date format in recording metadata")
                 }
                 let fileNamePrefix = fileName(phoneNumber: call.from, date: twilioDate, internalTestingMode: false)
                 let wavURL = directory.appending(component: fileNamePrefix + fileNameSuffixWAV)

--- a/Sources/App/Services/Helper/QuestionnaireStorageService.swift
+++ b/Sources/App/Services/Helper/QuestionnaireStorageService.swift
@@ -143,17 +143,22 @@ class QuestionnaireStorageService: Sendable {
 
     /// Hash the phone number for file naming (includes date for daily rotation)
     private func hashPhoneNumber(_ phoneNumber: String) -> String {
+        fileName(phoneNumber: phoneNumber, date: dateTimeCreated, internalTestingMode: featureFlags.internalTestingMode)
+    }
+}
+
+func fileName(phoneNumber: String, date: Date, internalTestingMode: Bool) -> String {
 #if DEBUG
         return "1"
 #else
         let formatter = DateFormatter()
-        if featureFlags.internalTestingMode {
+        if internalTestingMode {
             // For internal testing, allow for multiple responses per day by including timestamp
             formatter.dateFormat = "yyyy-MM-dd-HH-mm-ss"
         } else {
             formatter.dateFormat = "yyyy-MM-dd"
         }
-        let today = formatter.string(from: dateTimeCreated)
+        let today = formatter.string(from: date)
         let combinedString = phoneNumber + today
         
         // swiftlint:disable:next force_unwrapping
@@ -161,5 +166,4 @@ class QuestionnaireStorageService: Sendable {
         let hash = SHA256.hash(data: data)
         return hash.compactMap { String(format: "%02x", $0) }.joined().prefix(16).description
 #endif
-    }
 }


### PR DESCRIPTION
# Hashed file names for call recordings

## :recycle: Current situation & Problem
File names of call recordings shouldn't contain the phone numbers directly.


## :gear: Release Notes
- Uses hash of phone number and current date to decide file name of call recording.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
