### PR TITLE
Handle anonymous calling gracefully

### DIFF
--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -178,8 +178,12 @@ private func verifyWebhookSignature(
 
 private func extractPhoneNumberFromSIPHeaders(_ headers: [OpenAICAllIncomingEvent.SIPHeader])
     -> String? {
-    headers
-        .first { $0.name == "From" }?.value
+    (headers.first { $0.name == "From" }?.value)
+        .flatMap(extractPhoneNumberFromSIPHeader)
+}
+
+func extractPhoneNumberFromSIPHeader(value: String) -> String? {
+    value
         .components(separatedBy: ";")
         .first?
         .trimmingPrefix { $0 != "<" }
@@ -187,4 +191,6 @@ private func extractPhoneNumberFromSIPHeaders(_ headers: [OpenAICAllIncomingEven
         .trimmingPrefix("sip:")
         .components(separatedBy: "@")
         .first
+        .flatMap { try? /^\+[1-9]\d{1,14}$/.wholeMatch(in: $0)?.output }
+        .flatMap { $0.isEmpty ? nil : String($0) }
 }

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -84,4 +84,54 @@ struct AppTests {
             #expect(feedback == expected)
         }
     }
+
+    @Test(
+        "extractPhoneNumberFromSIPHeader extracts E.164 numbers",
+        arguments: [
+            // Standard E.164 in SIP From header
+            ("<sip:+14155551234@gateway.twilio.com>;tag=abc123", "+14155551234"),
+            // Minimal — just the SIP URI
+            ("<sip:+14155551234@10.0.0.1>", "+14155551234"),
+            // International numbers
+            ("<sip:+442071234567@gateway.twilio.com>;tag=xyz", "+442071234567"),
+            ("<sip:+4930123456@gateway.twilio.com>", "+4930123456"),
+            ("<sip:+61291234567@gateway.twilio.com>", "+61291234567"),
+            // Short numbers (some countries)
+            ("<sip:+1234@gateway.twilio.com>", "+1234"),
+            // Maximum length E.164 (15 digits)
+            ("<sip:+123456789012345@gateway.twilio.com>", "+123456789012345")
+        ]
+    )
+    func extractPhoneNumberValid(input: String, expected: String) {
+        #expect(extractPhoneNumberFromSIPHeader(value: input) == expected)
+    }
+
+    @Test(
+        "extractPhoneNumberFromSIPHeader returns nil for anonymous/invalid callers",
+        arguments: [
+            // Anonymous per RFC 3323
+            "<sip:anonymous@anonymous.invalid>",
+            // Common carrier-specific anonymous values
+            "<sip:anonymous@gateway.twilio.com>;tag=abc",
+            "<sip:restricted@gateway.twilio.com>",
+            "<sip:unknown@gateway.twilio.com>",
+            "<sip:unavailable@gateway.twilio.com>",
+            "<sip:private@gateway.twilio.com>",
+            "<sip:blocked@gateway.twilio.com>",
+            "<sip:withheld@gateway.twilio.com>",
+            // Missing + prefix (not E.164)
+            "<sip:14155551234@gateway.twilio.com>",
+            // Number too long (16+ digits)
+            "<sip:+1234567890123456@gateway.twilio.com>",
+            // Number with only + (no digits)
+            "<sip:+@gateway.twilio.com>",
+            // Leading zero after + (not valid E.164)
+            "<sip:+0123456789@gateway.twilio.com>",
+            // Empty string
+            ""
+        ]
+    )
+    func extractPhoneNumberNil(input: String) {
+        #expect(extractPhoneNumberFromSIPHeader(value: input) == nil)
+    }
 }


### PR DESCRIPTION
# Handle anonymous calling gracefully

## :recycle: Current situation & Problem
We have encountered an issue where repeated calls with blocked number actually potentially correlate with the same patient, since SIP references them with a static name (e.g. "anonymous"). We therefore would like to extract phone numbers only if they are actually valid phone numbers and ignore them in other cases. When they are ignored, they will be replaced with uuids.


## :gear: Release Notes
- Strictly check from headers for valid phone numbers and use uuid instead, if needed.


## :white_check_mark: Testing
- Added tests for header value extraction of phone numbers.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented phone number validation for extracted communication header data with proper format checking.

* **Tests**
  * Comprehensive test suite added for phone number validation across valid and invalid input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->