### PR TITLE
Adopt the Organization Repository Standards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 #
-# This source file is part of the ENGAGE-HF-AI-Voice open source project
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
 #
 # SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the ENGAGE-HF AI Voice open-source project
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
 #
 # SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -8,12 +8,12 @@
 
 coverage:
   status:
-    # Never let overall coverage slip; the project is at 31.25% today.
+    # Coverage may not fall more than 0.5 points below the base commit.
     project:
       default:
         target: auto
         threshold: 0.5%
-    # New code is held above the current project average so coverage climbs.
+    # New code must be better covered than the project average, so the average climbs.
     patch:
       default:
         target: 50%

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,21 @@
+#
+# This source file is part of the ENGAGE-HF AI Voice open-source project
+#
+# SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+coverage:
+  status:
+    # Never let overall coverage slip; the project is at 31.25% today.
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+    # New code is held above the current project average so coverage climbs.
+    patch:
+      default:
+        target: 50%
+
+comment: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+#
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
+#
+# SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+version: 2
+multi-ecosystem-groups:
+  weekly-dependencies:
+    schedule:
+      interval: "weekly"
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "weekly-dependencies"
+  - package-ecosystem: "swift"
+    directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "weekly-dependencies"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,6 +34,9 @@ jobs:
     uses: SchmiedmayerLab/.github/.github/workflows/docker-compose-test.yml@v0.5
   uploadcoveragereport:
     name: Upload Coverage Report
+    permissions:
+      actions: read
+      contents: read
     needs: [buildandtestmacos]
     uses: SchmiedmayerLab/.github/.github/workflows/coverage.yml@v0.5
     with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the ENGAGE-HF-AI-Voice open source project
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
 #
 # SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 #
@@ -15,13 +15,13 @@ on:
 jobs:
   reuse_action:
     name: REUSE Compliance Check
-    uses: StanfordBDHG/.github/.github/workflows/reuse.yml@v2
+    uses: SchmiedmayerLab/.github/.github/workflows/reuse.yml@v0.5
   swiftlint:
     name: SwiftLint
-    uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v2
+    uses: SchmiedmayerLab/.github/.github/workflows/swiftlint.yml@v0.5
   buildandtestmacos:
     name: Build and Test
-    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    uses: SchmiedmayerLab/.github/.github/workflows/xcodebuild-or-fastlane.yml@v0.5
     permissions:
       contents: read
     with:
@@ -31,11 +31,11 @@ jobs:
       artifactname: ENGAGE-HF-AI-Voice.xcresult
   dockercomposetest:
     name: Docker Compose Test
-    uses: StanfordBDHG/.github/.github/workflows/docker-compose-test.yml@v2
+    uses: SchmiedmayerLab/.github/.github/workflows/docker-compose-test.yml@v0.5
   uploadcoveragereport:
     name: Upload Coverage Report
     needs: [buildandtestmacos]
-    uses: StanfordBDHG/.github/.github/workflows/create-and-upload-coverage-report.yml@v2
+    uses: SchmiedmayerLab/.github/.github/workflows/coverage.yml@v0.5
     with:
       coveragereports: ENGAGE-HF-AI-Voice.xcresult
     secrets:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -21,6 +21,10 @@ concurrency:
 jobs:
   buildandpush:
     name: Build and Push to Container Registry
+    permissions:
+      actions: read
+      contents: read
+      packages: write
     uses: SchmiedmayerLab/.github/.github/workflows/docker-build-and-push.yml@v0.5
     secrets: inherit
     with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the ENGAGE-HF-AI-Voice open source project
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
 #
 # SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 #
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   buildandpush:
     name: Build and Push to Container Registry
-    uses: StanfordBDHG/.github/.github/workflows/docker-build-and-push.yml@v2
+    uses: SchmiedmayerLab/.github/.github/workflows/docker-build-and-push.yml@v0.5
     secrets: inherit
     with:
       imageName: ghcr.io/stanfordbdhg/engage-hf-ai-voice

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,17 @@ concurrency:
 jobs:
   buildandtest:
     name: Build and Test
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/build-and-test.yml
     secrets: inherit
   deployment:
     name: Deployment
+    permissions:
+      actions: read
+      contents: read
+      packages: write
     needs: buildandtest
     uses: ./.github/workflows/deployment.yml
     secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the ENGAGE-HF-AI-Voice open source project
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
 #
 # SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the ENGAGE-HF-AI-Voice open source project
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
 #
 # SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,5 +19,8 @@ concurrency:
 jobs:
   buildandtest:
     name: Build and Test
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/build-and-test.yml
     secrets: inherit

--- a/.github/workflows/repository-standards.yml
+++ b/.github/workflows/repository-standards.yml
@@ -1,0 +1,24 @@
+#
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
+#
+# SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Repository Standards
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  standards:
+    name: Standards
+    uses: SchmiedmayerLab/.github/.github/workflows/repository-standards.yml@v0.5

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #
-# This source file is part of the ENGAGE-HF-AI-Voice open source project
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
 #
 # SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the ENGAGE-HF-AI-Voice open source project
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
 #
 # SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the ENGAGE-HF-AI-Voice open source project
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
 #
 # SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 #
-# This source file is part of the ENGAGE-HF-AI-Voice open source project
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
 #
 # SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 #
@@ -8,15 +8,18 @@
 
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
+type: software
 authors:
-- family-names: "Schmiedmayer"
-  given-names: "Paul"
-  orcid: "https://orcid.org/0000-0002-8607-9148"
+- family-names: "Kraft"
+  given-names: "Paul Johannes"
+  orcid: "https://orcid.org/0000-0001-8157-8151"
 - family-names: "Madlener"
   given-names: "Nikolai"
   orcid: "https://orcid.org/0009-0006-5059-6617"
-- family-names: "Kraft"
-  given-names: "Paul Johannes"
+- family-names: "Schmiedmayer"
+  given-names: "Paul"
+  orcid: "https://orcid.org/0000-0002-8607-9148"
 title: "ENGAGE-HF-AI-Voice"
-doi: 10.5281/zenodo.7538165
-url: "https://github.com/StanfordBDHG/ENGAGE-HF-AI-Voice"
+license: MIT
+url: "https://github.com/SchmiedmayerLab/ENGAGE-HF-AI-Voice"
+repository-code: "https://github.com/SchmiedmayerLab/ENGAGE-HF-AI-Voice"

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,7 +1,7 @@
 <!--
                   
 #
-# This source file is part of the ENGAGE-HF-AI-Voice open source project
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
 #
 # SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 #
@@ -10,9 +10,7 @@
              
 -->
 
-ENGAGE-HF-AI-Voice contributors
-====================
-
-* [Paul Schmiedmayer](https://github.com/PSchmiedmayer)
-* [Nikolai Madlener](https://github.com/NikolaiMadlener)
+# ENGAGE-HF AI-Voice Contributors
 * [Paul Johannes Kraft](https://github.com/pauljohanneskraft)
+* [Nikolai Madlener](https://github.com/NikolaiMadlener)
+* [Paul Schmiedmayer](https://github.com/PSchmiedmayer)

--- a/Data Analysis/decrypt_files.sh
+++ b/Data Analysis/decrypt_files.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # 
 #
-# This source file is part of the ENGAGE-HF-AI-Voice open source project
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
 #
 # SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/Data Analysis/generate_session_reports.py
+++ b/Data Analysis/generate_session_reports.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# This source file is part of the ENGAGE-HF-AI-Voice open source project
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
 #
 # SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #
-# This source file is part of the ENGAGE-HF-AI-Voice open source project
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
 #
 # SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/Package.swift
+++ b/Package.swift
@@ -1,7 +1,7 @@
 // swift-tools-version:6.2
 
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 // 
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 // 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ SPDX-License-Identifier: MIT
 [![Deployment](https://github.com/SchmiedmayerLab/ENGAGE-HF-AI-Voice/actions/workflows/deployment.yml/badge.svg)](https://github.com/SchmiedmayerLab/ENGAGE-HF-AI-Voice/actions/workflows/deployment.yml)
 [![Codecov](https://codecov.io/gh/SchmiedmayerLab/ENGAGE-HF-AI-Voice/graph/badge.svg?token=UqiQBJqfZY)](https://codecov.io/gh/SchmiedmayerLab/ENGAGE-HF-AI-Voice)
 [![REUSE status](https://api.reuse.software/badge/github.com/SchmiedmayerLab/ENGAGE-HF-AI-Voice)](https://api.reuse.software/info/github.com/SchmiedmayerLab/ENGAGE-HF-AI-Voice)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/SchmiedmayerLab/ENGAGE-HF-AI-Voice/blob/main/LICENSE.md)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE.md)
 
 **Engage HF AI-Voice** is a [Vapor](https://vapor.codes/) server that integrates Twilio with OpenAI's real-time API (ChatGPT-4o) to enable voice-based conversations for healthcare data collection.
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 <!--
-                  
-This source file is part of the ENGAGE-HF-AI-Voice open source project
+
+This source file is part of the ENGAGE-HF AI-Voice open-source project
 
 SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 
 SPDX-License-Identifier: MIT
-             
+
 -->
 
 # ENGAGE HF AI-Voice
 
-[![Main](https://github.com/StanfordBDHG/ENGAGE-HF-AI-Voice/actions/workflows/main.yml/badge.svg)](https://github.com/StanfordBDHG/ENGAGE-HF-AI-Voice/actions/workflows/main.yml)
-[![codecov](https://codecov.io/gh/StanfordBDHG/ENGAGE-HF-AI-Voice/graph/badge.svg?token=UqiQBJqfZY)](https://codecov.io/gh/StanfordBDHG/ENGAGE-HF-AI-Voice)
+[![Build and Test](https://github.com/SchmiedmayerLab/ENGAGE-HF-AI-Voice/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/SchmiedmayerLab/ENGAGE-HF-AI-Voice/actions/workflows/build-and-test.yml)
+[![Deployment](https://github.com/SchmiedmayerLab/ENGAGE-HF-AI-Voice/actions/workflows/deployment.yml/badge.svg)](https://github.com/SchmiedmayerLab/ENGAGE-HF-AI-Voice/actions/workflows/deployment.yml)
+[![Codecov](https://codecov.io/gh/SchmiedmayerLab/ENGAGE-HF-AI-Voice/graph/badge.svg?token=UqiQBJqfZY)](https://codecov.io/gh/SchmiedmayerLab/ENGAGE-HF-AI-Voice)
+[![REUSE status](https://api.reuse.software/badge/github.com/SchmiedmayerLab/ENGAGE-HF-AI-Voice)](https://api.reuse.software/info/github.com/SchmiedmayerLab/ENGAGE-HF-AI-Voice)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/SchmiedmayerLab/ENGAGE-HF-AI-Voice/blob/main/LICENSE.md)
 
 **Engage HF AI-Voice** is a [Vapor](https://vapor.codes/) server that integrates Twilio with OpenAI's real-time API (ChatGPT-4o) to enable voice-based conversations for healthcare data collection.
 
@@ -281,15 +284,21 @@ The script will decrypt all files from `./vital_signs/`, `./kccq12_questionnairs
 
 ---
 
+## Contributing
+
+Contributions to this project are welcome. Please make sure to read the [contribution guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md) and the [contributor covenant code of conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) first. You can find a list of contributors in the [CONTRIBUTORS.md](CONTRIBUTORS.md) file.
+
 ## License
-This project is licensed under the MIT License. See [Licenses](https://github.com/StanfordBDHG/ENGAGE-HF-AI-Voice/tree/main/LICENSES) for more information.
 
----
+This project is licensed under the MIT License. See [LICENSE.md](LICENSE.md) for more information.
 
-## Contributors
-This project is developed as part of the Stanford Byers Center for Biodesign at Stanford University.
-See [CONTRIBUTORS.md](https://github.com/StanfordBDHG/ENGAGE-HF-AI-Voice/tree/main/CONTRIBUTORS.md) for a full list of all ENGAGE-HF-AI-Voice contributors.
+## Citation
 
-![Stanford Byers Center for Biodesign Logo](https://raw.githubusercontent.com/StanfordBDHG/.github/main/assets/biodesign-footer-light.png#gh-light-mode-only)
-![Stanford Byers Center for Biodesign Logo](https://raw.githubusercontent.com/StanfordBDHG/.github/main/assets/biodesign-footer-dark.png#gh-dark-mode-only)
+If you use this software, please cite it using the metadata in [CITATION.cff](CITATION.cff), which GitHub surfaces through the [*Cite this repository*](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) button.
 
+## Our Research
+
+For more information, visit the [Schmiedmayer Lab GitHub organization](https://github.com/SchmiedmayerLab).
+
+![Schmiedmayer Lab](https://raw.githubusercontent.com/SchmiedmayerLab/.github/main/assets/footer-light.png#gh-light-mode-only)
+![Schmiedmayer Lab](https://raw.githubusercontent.com/SchmiedmayerLab/.github/main/assets/footer-dark.png#gh-dark-mode-only)

--- a/Sources/App.docc/App.md
+++ b/Sources/App.docc/App.md
@@ -2,7 +2,7 @@
 
 <!--
 
-This source file is part of the ENGAGE-HF-AI-Voice open source project
+This source file is part of the ENGAGE-HF AI-Voice open-source project
 
 SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 

--- a/Sources/App/Models/FeatureFlags.swift
+++ b/Sources/App/Models/FeatureFlags.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Models/OpenAI/OpenAIError.swift
+++ b/Sources/App/Models/OpenAI/OpenAIError.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Models/OpenAI/OpenAIResponse.swift
+++ b/Sources/App/Models/OpenAI/OpenAIResponse.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Models/StorageKeys/EncryptionStorageKey.swift
+++ b/Sources/App/Models/StorageKeys/EncryptionStorageKey.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Models/StorageKeys/FeatureFlagsStorageKey.swift
+++ b/Sources/App/Models/StorageKeys/FeatureFlagsStorageKey.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Models/StorageKeys/OpenAIStorageKey.swift
+++ b/Sources/App/Models/StorageKeys/OpenAIStorageKey.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Models/StorageKeys/TwilioStorageKeys.swift
+++ b/Sources/App/Models/StorageKeys/TwilioStorageKeys.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Resources/MockData/kccq12_questionnairs/1.json.license
+++ b/Sources/App/Resources/MockData/kccq12_questionnairs/1.json.license
@@ -1,4 +1,4 @@
-This source file is part of the ENGAGE-HF-AI-Voice open source project
+This source file is part of the ENGAGE-HF AI-Voice open-source project
 
 SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 

--- a/Sources/App/Resources/MockData/q17/1.json.license
+++ b/Sources/App/Resources/MockData/q17/1.json.license
@@ -1,4 +1,4 @@
-This source file is part of the ENGAGE-HF-AI-Voice open source project
+This source file is part of the ENGAGE-HF AI-Voice open-source project
 
 SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 

--- a/Sources/App/Resources/MockData/vital_signs/1.json.license
+++ b/Sources/App/Resources/MockData/vital_signs/1.json.license
@@ -1,4 +1,4 @@
-This source file is part of the ENGAGE-HF-AI-Voice open source project
+This source file is part of the ENGAGE-HF AI-Voice open-source project
 
 SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 

--- a/Sources/App/Resources/kccq12.json.license
+++ b/Sources/App/Resources/kccq12.json.license
@@ -1,4 +1,4 @@
-This source file is part of the ENGAGE-HF-AI-Voice open source project
+This source file is part of the ENGAGE-HF AI-Voice open-source project
 
 SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 

--- a/Sources/App/Resources/kccq12Short.json.license
+++ b/Sources/App/Resources/kccq12Short.json.license
@@ -1,4 +1,4 @@
-This source file is part of the ENGAGE-HF-AI-Voice open source project
+This source file is part of the ENGAGE-HF AI-Voice open-source project
 
 SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 

--- a/Sources/App/Resources/q17.json.license
+++ b/Sources/App/Resources/q17.json.license
@@ -1,4 +1,4 @@
-This source file is part of the ENGAGE-HF-AI-Voice open source project
+This source file is part of the ENGAGE-HF AI-Voice open-source project
 
 SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 

--- a/Sources/App/Resources/sessionConfig.json.license
+++ b/Sources/App/Resources/sessionConfig.json.license
@@ -1,4 +1,4 @@
-This source file is part of the ENGAGE-HF-AI-Voice open source project
+This source file is part of the ENGAGE-HF AI-Voice open-source project
 
 SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 

--- a/Sources/App/Resources/vitalSigns.json.license
+++ b/Sources/App/Resources/vitalSigns.json.license
@@ -1,4 +1,4 @@
-This source file is part of the ENGAGE-HF-AI-Voice open source project
+This source file is part of the ENGAGE-HF AI-Voice open-source project
 
 SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 

--- a/Sources/App/Services/Call/CallHandler.swift
+++ b/Sources/App/Services/Call/CallHandler.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Call/CallSession.swift
+++ b/Sources/App/Services/Call/CallSession.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Questionnaire/CallFlowCoordinator.swift
+++ b/Sources/App/Services/Questionnaire/CallFlowCoordinator.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Questionnaire/EngageHF/EngageHFFeedbackProvider.swift
+++ b/Sources/App/Services/Questionnaire/EngageHF/EngageHFFeedbackProvider.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Questionnaire/EngageHF/EngageHFSections.swift
+++ b/Sources/App/Services/Questionnaire/EngageHF/EngageHFSections.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Questionnaire/EngageHF/KCCQ12ScoreCalculator.swift
+++ b/Sources/App/Services/Questionnaire/EngageHF/KCCQ12ScoreCalculator.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Questionnaire/FHIRQuestionnaireEngine.swift
+++ b/Sources/App/Services/Questionnaire/FHIRQuestionnaireEngine.swift
@@ -146,10 +146,10 @@ class FHIRQuestionnaireEngine: Sendable {
 
     /// Record an answer for a given linkId.
     func answerQuestion<T>(linkId: String, answer: T) throws {
-        let responseItem = QuestionnaireResponseItem(
+        var responseItem = QuestionnaireResponseItem(
             linkId: FHIRPrimitive(FHIRString(linkId))
         )
-        let answerItem = QuestionnaireResponseItemAnswer()
+        var answerItem = QuestionnaireResponseItemAnswer()
 
         guard let questionnaireItem = findQuestionnaireItem(linkId: linkId) else {
             throw QuestionnaireEngineError.unknownLinkId(linkId)

--- a/Sources/App/Services/Questionnaire/FHIRQuestionnaireEngine.swift
+++ b/Sources/App/Services/Questionnaire/FHIRQuestionnaireEngine.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Questionnaire/Feedback/DecisionNode.swift
+++ b/Sources/App/Services/Questionnaire/Feedback/DecisionNode.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Questionnaire/Feedback/FeedbackDecisionTreeBuilder.swift
+++ b/Sources/App/Services/Questionnaire/Feedback/FeedbackDecisionTreeBuilder.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Questionnaire/Feedback/FeedbackProvider.swift
+++ b/Sources/App/Services/Questionnaire/Feedback/FeedbackProvider.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Questionnaire/Feedback/PatientData.swift
+++ b/Sources/App/Services/Questionnaire/Feedback/PatientData.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Questionnaire/QuestionWithProgress.swift
+++ b/Sources/App/Services/Questionnaire/QuestionWithProgress.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Questionnaire/QuestionnaireResponseArgs.swift
+++ b/Sources/App/Services/Questionnaire/QuestionnaireResponseArgs.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Questionnaire/QuestionnaireResponseItemAnswer+IntegerValue.swift
+++ b/Sources/App/Services/Questionnaire/QuestionnaireResponseItemAnswer+IntegerValue.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Questionnaire/QuestionnaireResponseStore.swift
+++ b/Sources/App/Services/Questionnaire/QuestionnaireResponseStore.swift
@@ -77,6 +77,7 @@ class QuestionnaireResponseStore: Sendable {
     }
 
     func saveResponse(_ response: QuestionnaireResponse) {
+        var response = response
         do {
             try FileManager.default.createDirectory(
                 atPath: directoryURL.path,
@@ -129,7 +130,7 @@ class QuestionnaireResponseStore: Sendable {
     }
 
     private func makeEmptyResponse(phoneNumber: String) -> QuestionnaireResponse {
-        let response = QuestionnaireResponse(
+        var response = QuestionnaireResponse(
             status: FHIRPrimitive(QuestionnaireResponseStatus.inProgress)
         )
         response.subject = .init(reference: FHIRPrimitive(FHIRString(phoneNumber)))

--- a/Sources/App/Services/Questionnaire/QuestionnaireResponseStore.swift
+++ b/Sources/App/Services/Questionnaire/QuestionnaireResponseStore.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Questionnaire/QuestionnaireSection.swift
+++ b/Sources/App/Services/Questionnaire/QuestionnaireSection.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Questionnaire/SimplifiedQuestion.swift
+++ b/Sources/App/Services/Questionnaire/SimplifiedQuestion.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Recording/CallRecordingDecryptor.swift
+++ b/Sources/App/Services/Recording/CallRecordingDecryptor.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Recording/CallRecordingService.swift
+++ b/Sources/App/Services/Recording/CallRecordingService.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Recording/TwilioAPI.swift
+++ b/Sources/App/Services/Recording/TwilioAPI.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Utilities/EncryptionService.swift
+++ b/Sources/App/Services/Utilities/EncryptionService.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/Services/Utilities/FileNaming.swift
+++ b/Sources/App/Services/Utilities/FileNaming.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/constants.swift
+++ b/Sources/App/constants.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -1,5 +1,5 @@
 //
-// This source file is part of the ENGAGE-HF-AI-Voice open source project
+// This source file is part of the ENGAGE-HF AI-Voice open-source project
 //
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the ENGAGE-HF-AI-Voice open source project
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
 #
 # SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the ENGAGE-HF-AI-Voice open source project
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
 #
 # SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the ENGAGE-HF-AI-Voice open source project
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
 #
 # SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,5 @@
 #
-# This source file is part of the ENGAGE-HF-AI-Voice open source project
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
 #
 # SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/nginx.local.conf
+++ b/nginx.local.conf
@@ -1,5 +1,5 @@
 #
-# This source file is part of the ENGAGE-HF-AI-Voice open source project
+# This source file is part of the ENGAGE-HF AI-Voice open-source project
 #
 # SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 #


### PR DESCRIPTION
### :recycle: Current situation & Problem

`SchmiedmayerLab/.github` defines the organization repository standard in [`REPOSITORY_STANDARDS.md`](https://github.com/SchmiedmayerLab/.github/blob/main/REPOSITORY_STANDARDS.md) and enforces it in `repository-standards.yml`. This repository does not call that workflow yet.

No related issue was identified.

### :gear: Release Notes

- Call `repository-standards.yml@v0.5` from a new `.github/workflows/repository-standards.yml`.
- Pin every shared workflow reference to `v0.5`.
- Complete `CITATION.cff` with the fields Zenodo reads, and bring `CONTRIBUTORS.md` to the documented shape.
- Add the badge block and the Contributing, License, Citation and Our Research sections to the README.
- Group Dependabot updates into a single weekly pull request.
- Name the same project in every SPDX header.

### :books: Documentation

The standard is documented in [`REPOSITORY_STANDARDS.md`](https://github.com/SchmiedmayerLab/.github/blob/main/REPOSITORY_STANDARDS.md).

### :white_check_mark: Testing

- `actionlint`, `yamllint` and `reuse lint`
- `repository-standards.yml@v0.5` runs on this pull request

### Code of Conduct & Contributing Guidelines

By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).