### PR TITLE
Publish the Container Image Under the SchmiedmayerLab Namespace

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -28,4 +28,4 @@ jobs:
     uses: SchmiedmayerLab/.github/.github/workflows/docker-build-and-push.yml@v0.5
     secrets: inherit
     with:
-      imageName: ghcr.io/stanfordbdhg/engage-hf-ai-voice
+      imageName: schmiedmayerlab/engage-hf-ai-voice

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -11,7 +11,7 @@ version: '3.8'
 
 services:
   app:
-    image: ghcr.io/stanfordbdhg/engage-hf-ai-voice:main
+    image: ghcr.io/schmiedmayerlab/engage-hf-ai-voice:main
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY:?OPENAI_API_KEY is required}
       - OPENAI_WEBHOOK_SECRET=${OPENAI_WEBHOOK_SECRET:?OPENAI_WEBHOOK_SECRET is required}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,7 +11,7 @@ version: '3.8'
 
 services:
   app:
-    image: ghcr.io/stanfordbdhg/engage-hf-ai-voice:main
+    image: ghcr.io/schmiedmayerlab/engage-hf-ai-voice:main
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY:?OPENAI_API_KEY is required}
       - OPENAI_WEBHOOK_SECRET=${OPENAI_WEBHOOK_SECRET:?OPENAI_WEBHOOK_SECRET is required}


### PR DESCRIPTION
### :recycle: Current situation & Problem
The `Deployment` workflow has never been able to push an image. It passed `imageName: ghcr.io/stanfordbdhg/engage-hf-ai-voice`, but the shared `docker-build-and-push.yml` documents `imageName` as the name *without* the registry (`schmiedmayerlab/example`) and prepends `registry` itself. Every push target therefore came out as `ghcr.io/ghcr.io/stanfordbdhg/engage-hf-ai-voice`, and the run failed at "Build and push by digest".

The namespace was wrong independently of the doubling: the repository lives in `SchmiedmayerLab`, so its `GITHUB_TOKEN` has no write access to a `stanfordbdhg` package.

### :gear: Release Notes
- The container image is now published as `ghcr.io/schmiedmayerlab/engage-hf-ai-voice`.
- `docker-compose.local.yml` and `docker-compose.prod.yml` pull from the new location.

The image under `ghcr.io/stanfordbdhg/engage-hf-ai-voice` stays where it is and receives no further updates. Deployments pinning it keep working against the last image published there and need to move to the new name to pick up anything newer. The new package is created on the first successful push to `main` and starts out private; it needs to be made public in the organization's package settings for unauthenticated pulls to work.

### :books: Documentation
The change is a workflow input and two Compose image references; the shared workflow already documents the expected `imageName` format.

### :white_check_mark: Testing
Not unit-testable — the deployment workflow only runs on `main` and on tags. Verified by reading the shared workflow: `docker-build-and-push.yml` builds every push target as `${registry}/${imageName}`, both for the per-architecture digests and for the manifest list, which is what produced the doubled registry.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
